### PR TITLE
Add link to virtual workshop slide decks to 01_workshops.md.

### DIFF
--- a/_current_challenges/01_workshops.md
+++ b/_current_challenges/01_workshops.md
@@ -23,7 +23,7 @@ Participation is relatively limited but we are checking on whether virtual atten
 
 ## The SAMPL6 LogP Virtual Workshop
 
-We had a virtual pre-workshop on the SAMPL6 LogP challenge on Thursday, May 16, beginning at 7 am US Pacific time.  [SAMPL6 logP virtual workshop video](https://www.youtube.com/watch?v=FWUPXG8U3UE) is now available.
+We had a virtual pre-workshop on the SAMPL6 LogP challenge on Thursday, May 16, beginning at 7 am US Pacific time.  [SAMPL6 logP virtual workshop video](https://www.youtube.com/watch?v=FWUPXG8U3UE) and [presentation slides](https://github.com/choderalab/SAMPL6-logP-challenge-virtual-workshop) are now available.
 
 ### Overview/Purpose
 


### PR DESCRIPTION
This PR adds a  link to virtual workshop slide decks to 01_workshops.md, as reflected here:
https://github.com/samplchallenges/samplchallenges.github.io/blob/SAMPL6_virtual_workshop_slides/_current_challenges/01_workshops.md#the-sampl6-logp-virtual-workshop

Presentation files are hosted in a different repo without any license:
https://github.com/choderalab/SAMPL6-logP-challenge-virtual-workshop